### PR TITLE
Release 3.1.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 Changelog
 =========
+ * v3.1.4 (2019-05-08)
+   - Fixed `get()` not being properly exported.
+   - Internal library code cleanup.
+
  * v3.1.3 (2019-02-19)
    - Corrected `versionCode` and `versionName`.
    - Fixed Java interface.
@@ -23,24 +27,24 @@ Changelog
  * v2.1.0 (2018-02-24)
    - `regularTypeface()` is now deprecated. Use `normalTypeface()`
    - Typeface fallback is now enabled by default
-   - Fixed navigation drawer's header in demo app not showing any content
+   - Fixed navigation drawer's header in demo app not showing any content.
 
  * v2.0.0 (2017-04-24)
-   - Renamed `init()` method to `context()`
-   - Configuration chain now must end with `done()`
-   - Improved public methods argument validation
-   - [#1] Added italic support (`italicTypeface()`)
-   - Added typeface fallback feature. See `typefaceFallback()`
-   - Fixed styling of `TextInputLayout`'s `EditText` widget
-   - Added `NavigationDrawer` and `Toolbar` to demo app
+   - Renamed `init()` method to `context()`.
+   - Configuration chain now must end with `done()`.
+   - Improved public methods argument validation.
+   - [#1] Added italic support (`italicTypeface()`).
+   - Added typeface fallback feature. See `typefaceFallback()`.
+   - Fixed styling of `TextInputLayout`'s `EditText` widget.
+   - Added `NavigationDrawer` and `Toolbar` to demo app.
 
  * v1.2.0 (2017-04-23)
-   - [#2] Added support for `TextInputLayout`
+   - [#2] Added support for `TextInputLayout`.
 
  * v1.1.0 (2017-03-12)
    - Default font dir is `fonts/`
-   - `fontDir()` accepts `null` as argument
-   - `addTypeface()` is now `add()`
+   - `fontDir()` accepts `null` as argument.
+   - `addTypeface()` is now `add()`.
 
  * v1.0.0 (2017-03-11)
-   - Initial public release
+   - Initial public release.

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Fonty
  [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-Fonty-brightgreen.svg?style=flat)](https://android-arsenal.com/details/1/5489)
 
 
- `Fonty` is simple Android library allowing you to easily change the typeface
- of your UI elements. Contrary to other implementations `Fonty` is designed with
- the assumption that if you want to change the font for your  app, then you change
- it **globally** per whole application, to achieve consistency across your Fragments
- or Activities.
+ `Fonty` is simple Android library allowing you to easily change the typeface of your UI elements.
+ Contrary to other libraries of that type, `Fonty` is designed with the assumption that if you want
+ to change the font for your app, then you change it **globally** per whole application, to achieve
+ consistency across your Fragments or Activities. If you want different fonts per each widget, then
+ `Fonty` is most likely not what you need.
 
  Using `Fonty` requires **no change** to your layout files and all you need to do is to initialize 
  the library and specify what typeface you want to be used as normal, italic or boldfaced ones.
@@ -27,10 +27,11 @@ Fonty
 Features
 ========
 
+ - Does not require any changes to your layout XML files,
  - Fast and lightweight,
  - No extra dependencies,
  - Simple API,
- - Supports the following UI elements and all subclasses:,
+ - Supports the following UI elements and all their subclasses:
    * `TextInputLayout` (see [notes](#textinputlayout) below!),
    * `Navigation Drawer` (including drawer's header view),
    * `Toolbar`
@@ -60,8 +61,9 @@ Installation
 Configuration
 =============
 
- Put your [TrueType](https://en.wikipedia.org/wiki/TrueType) (`*.ttf`) font files into module's `assets/fonts`
- folder (`<MODULE>/src/main/assets/fonts` folder, where `<MODULE>` usually equals `app`).
+ Put your [TrueType](https://en.wikipedia.org/wiki/TrueType) (`*.ttf`) font files into module's
+ `assets/fonts` folder (`<MODULE>/src/main/assets/fonts` folder, where `<MODULE>` usually equals
+ to `app`).
 
  Then add the following lines to your custom Application's class' `onCreate()`
  method (if you do not use own `Application` subclass, see demo app for how
@@ -208,11 +210,11 @@ Limitations
 ===========
 
  Due to limitations of the Android API, once fonts are replaced by `Fonty`, former style information
- (like `bold`, `normal`) is reset, so all calls to i.e. `isBold()` or `isItalic()` will always
- return `false`. At the moment there's no workaround for this issue, yet it should not really
- affect many, however because this information is gone, and `Fonty` relies on it then calling
+ (like `bold`, `normal`) is lost, so all calls to i.e. `isBold()` or `isItalic()` will always
+ return `false`. However because this information is gone, and `Fonty` relies on it, calling
  `Fonty.setFonts()` twice on the same layout elements will end up with wrong results (mostly
- all widgets will be using normal typeface).
+ all widgets will be using normal typeface). At the moment there's no workaround for this except
+ for not calling `setFonts()` more than once. Hopefuly IRL scenarios this should not affect many.
 
 
 Contributing
@@ -221,8 +223,8 @@ Contributing
  Please report any issue spotted using [GitHub's project tracker](https://github.com/MarcinOrlowski/fonty/issues).
 
  If you'd like to contribute to the this project, please [open new ticket](https://github.com/MarcinOrlowski/fonty/issues)
- **before doing any work**. This will help us save your time in case I'd not be able to accept such changes. But if all is good and
- clear then follow common routine:
+ **before doing any work**. This will help us save your time in case I'd not be able to accept such
+ changes. But if all is good and clear then follow common routine:
 
   * fork the project
   * create new branch

--- a/README.md
+++ b/README.md
@@ -27,17 +27,16 @@ Fonty
 Features
 ========
 
- - Fast and lightweight
- - No odd dependencies
- - Simple API
- - Supports the following UI elements and all subclasses:
-   * TextInputLayout (see [notes](#textinputlayout) below!)
-   * Navigation Drawer (including drawer's header view)
-   * Toolbar
-   * TextView (incl. Checkbox, EditText, CheckedTextView, Chronometer, DigitalClock, TextClock, ...)
-   * Button (incl. Switch, RadioButton, CompoundButton, ...)
- - Can be used in libraries
-
+ - Fast and lightweight,
+ - No extra dependencies,
+ - Simple API,
+ - Supports the following UI elements and all subclasses:,
+   * `TextInputLayout` (see [notes](#textinputlayout) below!),
+   * `Navigation Drawer` (including drawer's header view),
+   * `Toolbar`
+   * `TextView` (incl. `Checkbox`, `EditText`, `CheckedTextView`, `Chronometer`, `DigitalClock`, `TextClock`, ...),
+   * `Button` (incl. `Switch`, `RadioButton`, `CompoundButton`, ...),
+ - Can be used in libraries.
 
 Installation
 ============
@@ -91,10 +90,6 @@ Configuration
         .build();
 
  and put your font files into `<MODULE>/src/main/assets/my-fonts` folder.
-
- **NOTE:** You **MUST** call `fontDir()` **before** invoking `xxxTypeface()` in your setup chain,
- otherwise `xxxTypeface()` will try to look for fonts in default location and end
- up failing throwing exception due to missing typeface file.
 
 Font substitution
 =================

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
 
         //noinspection HighAppVersionCode
-        versionCode 2019021903
+        versionCode 2019050801
         versionName '3.1.3'
     }
     buildTypes {

--- a/app/src/main/java/com/marcinorlowski/fonty/demo/MainActivity.kt
+++ b/app/src/main/java/com/marcinorlowski/fonty/demo/MainActivity.kt
@@ -62,12 +62,12 @@ class MainActivity : AppCompatActivity() {
             actionBar.setDisplayHomeAsUpEnabled(true)
             mDrawerToggle = object : ActionBarDrawerToggle(this, drawerLayout, toolbar, R.string.toggle_opend, R.string.toggle_closed) {
                 override fun onDrawerClosed(drawerView: View) {
-                    super.onDrawerClosed(drawerView!!)
+                    super.onDrawerClosed(drawerView)
                     invalidateOptionsMenu()
                 }
 
                 override fun onDrawerOpened(drawerView: View) {
-                    super.onDrawerOpened(drawerView!!)
+                    super.onDrawerOpened(drawerView)
                     invalidateOptionsMenu()
                 }
             }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:3.4.0'
 
         // https://github.com/ben-manes/gradle-versions-plugin
         // Usage: gradlew dependencyUpdates task to check dependency versions

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Feb 18 06:18:48 PST 2019
+#Wed May 08 11:55:50 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -15,8 +15,8 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
 
         //noinspection HighAppVersionCode
-        versionCode 2019021903
-        versionName '3.1.3'
+        versionCode 2019050801
+        versionName '3.1.4'
     }
     buildTypes {
         release {

--- a/lib/src/main/java/com/marcinorlowski/fonty/Fonty.kt
+++ b/lib/src/main/java/com/marcinorlowski/fonty/Fonty.kt
@@ -70,17 +70,17 @@ class Fonty {
             return
         }
 
-        var fontDir = fontDir
+        var dir = fontDir
 
-        if (fontDir != "") {
-            if (fontDir.substring(fontDir.length - 1) != "/") {
-                if (fontDir != "") {
-                    fontDir = "$fontDir/"
+        if (dir != "") {
+            if (dir.substring(dir.length - 1) != "/") {
+                if (dir != "") {
+                    dir = "$dir/"
                 }
             }
         }
 
-        fontFolderName = fontDir
+        fontFolderName = dir
     }
 
     /**
@@ -139,7 +139,7 @@ class Fonty {
     fun normalTypeface(fileName: String): Fonty {
         failIfConfigured()
 
-        normalTypefaceNameTmp = fileName!!
+        normalTypefaceNameTmp = fileName
         normalTypefaceIdTmp = null
         return this
     }
@@ -154,7 +154,7 @@ class Fonty {
     fun normalTypeface(fileNameId: Int): Fonty {
         failIfConfigured()
 
-        normalTypefaceIdTmp = fileNameId!!
+        normalTypefaceIdTmp = fileNameId
         normalTypefaceNameTmp = null
         return this
     }
@@ -174,7 +174,7 @@ class Fonty {
     fun italicTypeface(fileName: String): Fonty {
         failIfConfigured()
 
-        italicTypefaceNameTmp = fileName!!
+        italicTypefaceNameTmp = fileName
         italiclTypefaceIdTmp = null
         return this
     }
@@ -189,7 +189,7 @@ class Fonty {
     fun italicTypeface(fileNameId: Int): Fonty {
         failIfConfigured()
 
-        italiclTypefaceIdTmp = fileNameId!!
+        italiclTypefaceIdTmp = fileNameId
         italicTypefaceNameTmp = null
         return this
     }
@@ -231,21 +231,21 @@ class Fonty {
      * fontDir is not used.
      */
     private fun add(alias: String, fontFileName: String): Fonty {
-        var fontFileName = fontFileName
-
         when {
             alias.isEmpty() -> throw RuntimeException("Typeface alias cannot be empty string")
             fontFileName.isEmpty() -> throw RuntimeException("Typeface filename cannot be empty string")
         }
 
+        var fontFile = fontFileName
+
         // strip leading "/" if present
-        fontFileName = if (fontFileName.substring(0, 1) == "/") {
-            fontFileName.substring(1)
+        fontFile = if (fontFile.substring(0, 1) == "/") {
+            fontFile.substring(1)
         } else {
-            fontFolderName + fontFileName
+            fontFolderName + fontFile
         }
 
-        Cache.instance.add(mContext!!, alias, fontFileName)
+        Cache.instance.add(mContext!!, alias, fontFile)
 
         return this
     }
@@ -312,12 +312,12 @@ class Fonty {
         // --------------------------------------------------------------------------------------------
 
         fun initWithContext(context: Context): Fonty {
-            if (!Context::class.java.isInstance(context!!)) {
+            if (!Context::class.java.isInstance(context)) {
                 throw IllegalArgumentException("Invalid Context object passed.")
             }
 
             if (instance_ == null) {
-                instance_ = Fonty(context!!)
+                instance_ = Fonty(context)
             }
 
             return instance_!!
@@ -351,6 +351,7 @@ class Fonty {
          *
          * @return the typeface
          */
+        @JvmStatic
         operator fun get(alias: String): Typeface? {
             return Cache.instance[alias]
         }


### PR DESCRIPTION
   - Fixed `get()` not being properly exported.
   - Internal library code cleanup.